### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Manifest.toml
 test/draft.jl
 test/MOItests.jl
 test/quadratic_tests.jl
+*.json
+*.txt

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 [extras]
 GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "GLPK", "Ipopt", "JuMP"]

--- a/README.md
+++ b/README.md
@@ -18,3 +18,21 @@ GSOC 2020 project
 
 Repository with implementation allowing parameters in MathOptInterface.jl problems.
 
+
+## Benchmarking
+
+In the development of ParametricOptInterface.jl it is useful to benchmark the MOI wrapper code performance.
+To perform benchmark we recommend you compare the performance of the master branch aggaints your 
+implementation. Here we leave an example on how to perform the benchmarks the correct way.
+
+1. before starting your implementation run a baseline benchmark aggainst the branch `master`.
+```
+git checkout master
+julia --project=benchmark benchmark/benchmark.jl --new bench
+```
+ 2. While testing your implementation benchmark your approach against the baseline benchmark.
+```
+git checkout approach_1
+julia --project=benchmark benchmark/benchmark.jl --compare bench
+```
+When you are ready to make a PR please report the `report.txt` file content in the PR.

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,3 +1,3 @@
 [deps]
-GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -1,0 +1,70 @@
+push!(LOAD_PATH, "./src")
+using ParametricOptInterface, MathOptInterface, GLPK
+
+const POI = ParametricOptInterface
+const MOI = MathOptInterface
+
+MOI.Benchmarks.@add_benchmark function add_constrained_variable(new_model)
+    model = new_model()
+    for _ in 1:10_000
+        MOI.add_constrained_variable(model, POI.Parameter(0))
+    end
+    return
+end
+
+MOI.Benchmarks.@add_benchmark function add_constraint_svf(new_model)
+    model = new_model()
+    x = MOI.add_variables(model, 10_000)
+    for i in 1:10_000
+        MOI.add_constraint(model, MOI.SingleVariable(x[i]), MOI.GreaterThan(1.0))
+    end
+    return
+end
+
+MOI.Benchmarks.@add_benchmark function add_constraint_saf(new_model)
+    model = new_model()
+    x = MOI.add_variables(model, 10_000)
+    for i in 1:10_000
+        y, cy = MOI.add_constrained_variable(model, POI.Parameter(0))
+        con = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.5], [x[i], y]), 0.0)
+        MOI.add_constraint(model, con, MOI.GreaterThan(1.0))
+    end
+    return
+end
+
+function print_help()
+    println("""
+    Usage
+        benchmark.jl [arg] [name]
+    [arg]
+        --new       Begin a new benchmark comparison
+        --compare   Run another benchmark and compare to existing
+    [name]          A name for the benchmark test
+    Examples
+        git checkout master
+        julia benchmark.jl --new master
+        git checkout approach_1
+        julia benchmark.jl --new approach_1
+        git checkout approach_2
+        julia benchmark.jl --compare master
+        julia benchmark.jl --compare approach_1
+    """)
+end
+
+if length(ARGS) != 2
+    print_help()
+else
+    const Benchmarks = GLPK.MOI.Benchmarks
+    const suite = Benchmarks.suite(() -> POI.ParametricOptimizer(GLPK.Optimizer()); exclude = [r"delete", r"copy"])
+    if ARGS[1] == "--new"
+        Benchmarks.create_baseline(
+            suite, ARGS[2]; directory = @__DIR__, verbose = true
+        )
+    elseif ARGS[1] == "--compare"
+        Benchmarks.compare_against_baseline(
+            suite, ARGS[2]; directory = @__DIR__, verbose = true
+        )
+    else
+        print_help()
+    end
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,3 @@
-push!(LOAD_PATH,"../src/")
-
 using Documenter, ParametricOptInterface
 
 makedocs(

--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -326,15 +326,15 @@ function MOI.add_constraint(model::ParametricOptimizer, f::MOI.ScalarAffineFunct
 end
 
 function update_constant!(s::MOI.LessThan{T}, val) where T
-    MOI.LessThan{T}(s.upper - val)
+    return MOI.LessThan{T}(s.upper - val)
 end
 
 function update_constant!(s::MOI.GreaterThan{T}, val) where T
-    MOI.GreaterThan{T}(s.lower - val)
+    return MOI.GreaterThan{T}(s.lower - val)
 end
 
 function update_constant!(s::MOI.EqualTo{T}, val) where T
-    MOI.EqualTo{T}(s.value - val)
+    return MOI.EqualTo{T}(s.value - val)
 end
 
 function MOI.get(model::ParametricOptimizer, attr::MOI.VariablePrimal, v::MOI.VariableIndex)

--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -161,7 +161,7 @@ function MOI.get(model::ParametricOptimizer, attr::MOI.VariableName, v::MOI.Vari
 end
 
 function MOI.supports(model::ParametricOptimizer, attr::MOI.VariableName, tp::Type{MOI.VariableIndex})
-    MOI.supports(model.optimizer, attr, tp)
+    return MOI.supports(model.optimizer, attr, tp)
 end
 
 function MOI.set(model::ParametricOptimizer, attr::MOI.ConstraintName, c::MOI.ConstraintIndex, name::String)
@@ -195,7 +195,7 @@ function MOI.get(model::ParametricOptimizer, attr::MOI.ConstraintSet, ci::MOI.Co
 end
 
 function MOI.get(model::ParametricOptimizer, attr::MOI.ObjectiveSense)
-    MOI.get(model.optimizer, attr)
+    return MOI.get(model.optimizer, attr)
 end
 
 # TODO
@@ -233,7 +233,7 @@ function MOI.get(
     MOI.VectorOfVariables,
     MOI.SingleVariable,
 }}
-    MOI.get(model.optimizer, attr)
+    return MOI.get(model.optimizer, attr)
 end
 
 # TODO
@@ -283,7 +283,7 @@ function MOI.add_constrained_variable(model::ParametricOptimizer, set::Parameter
     model.last_index_added += 1
     p = MOI.VariableIndex(model.last_index_added)
     model.parameters[p] = set.val
-    cp = MOI.ConstraintIndex{MOI.SingleVariable, typeof(set)}(model.last_index_added)
+    cp = MOI.ConstraintIndex{MOI.SingleVariable, Parameter}(model.last_index_added)
     return p, cp
 end
 
@@ -297,30 +297,78 @@ function MOI.add_constraint(model::ParametricOptimizer, f::MOI.SingleVariable, s
     end
 end
 
-function MOI.add_constraint(model::ParametricOptimizer, f::MOI.ScalarAffineFunction{T}, set::MOI.AbstractScalarSet) where T   
-    if !any(haskey(model.parameters, f.terms[i].variable_index) for i = 1:length(f.terms))
-        return MOI.add_constraint(model.optimizer, f, set) 
-    else
-        vars = MOI.ScalarAffineTerm{T}[]
-        params = MOI.ScalarAffineTerm{T}[]
+function function_has_parameters(model::ParametricOptimizer, f::MOI.ScalarAffineFunction{T}) where T
+    for term in f.terms
+        if haskey(model.parameters, term.variable_index)
+            return true
+        end
+    end
+    return false
+end
+function function_has_parameters(model::ParametricOptimizer, f::MOI.VectorOfVariables)
+    for variable in f.variables
+        if haskey(model.parameters, variable)
+            return true
+        end
+    end
+    return false
+end
+function function_has_parameters(model::ParametricOptimizer, f::MOI.VectorAffineFunction{T}) where T
+    for term in f.terms
+        if haskey(model.parameters, term.variable_index)
+            return true
+        end
+    end
+    return false
+end
+function function_has_parameters(model::ParametricOptimizer, f::MOI.ScalarQuadraticFunction{T}) where T
+    return function_affine_terms_has_parameters(model, f.affine_terms) ||
+           function_quadratic_terms_has_parameters(model, f.quadratic_terms)
+end
+function function_affine_terms_has_parameters(model::ParametricOptimizer, affine_terms)
+    for term in affine_terms
+        if haskey(model.parameters, term.variable_index)
+            return true
+        end
+    end
+    return false
+end
+function function_quadratic_terms_has_parameters(model::ParametricOptimizer, quadratic_terms)
+    for term in quadratic_terms
+        if haskey(model.parameters, term.variable_index_1) || haskey(model.parameters, term.variable_index_2)
+            return true
+        end
+    end
+    return false
+end
 
-        for i in f.terms
-            if haskey(model.variables, i.variable_index)
-                push!(vars, i)
-            elseif haskey(model.parameters, i.variable_index)
-                push!(params, i)
-            else
-                error("Constraint uses a variable that is not in the model")
-            end
+function add_constraint_with_parameters_on_function(model::ParametricOptimizer, f::MOI.ScalarAffineFunction{T}, set::MOI.AbstractScalarSet) where T  
+    vars = MOI.ScalarAffineTerm{T}[]
+    params = MOI.ScalarAffineTerm{T}[]
+
+    for term in f.terms
+        if haskey(model.variables, term.variable_index)
+            push!(vars, term)
+        elseif haskey(model.parameters, term.variable_index)
+            push!(params, term)
+        else
+            error("Constraint uses a variable that is not in the model")
         end
-        param_constant = 0
-        for j in params
-            param_constant += j.coefficient * model.parameters[j.variable_index]
-        end
-        fvar = MOI.ScalarAffineFunction(vars, f.constant + param_constant)
-        ci = MOIU.normalize_and_add_constraint(model.optimizer, fvar, set)     
-        model.affine_constraint_cache[ci] = params
-        return ci
+    end
+    param_constant = 0
+    for param in params
+        param_constant += param.coefficient * model.parameters[param.variable_index]
+    end
+    ci = MOIU.normalize_and_add_constraint(model.optimizer, MOI.ScalarAffineFunction(vars, f.constant + param_constant), set)     
+    model.affine_constraint_cache[ci] = params
+    return ci
+end
+
+function MOI.add_constraint(model::ParametricOptimizer, f::MOI.ScalarAffineFunction{T}, set::MOI.AbstractScalarSet) where T   
+    if !function_has_parameters(model, f)
+        return MOI.add_constraint(model.optimizer, f, set)
+    else
+        return add_constraint_with_parameters_on_function(model, f, set)
     end
 end
 
@@ -375,24 +423,24 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.ObjectiveFunction, f::MOI
     model.quadratic_objective_cache_pc = Vector{MOI.ScalarQuadraticTerm{T}}()
 
 
-    if !any(haskey(model.parameters, f.terms[i].variable_index) for i = 1:length(f.terms))
+    if !function_has_parameters(model, f)
         MOI.set(model.optimizer, attr, f) 
         return
     else
         vars = MOI.ScalarAffineTerm{T}[]
         params = MOI.ScalarAffineTerm{T}[]
-        for i in f.terms
-            if haskey(model.variables, i.variable_index)
-                push!(vars, i)
-            elseif haskey(model.parameters, i.variable_index)
-                push!(params, i)
+        for term in f.terms
+            if haskey(model.variables, term.variable_index)
+                push!(vars, term)
+            elseif haskey(model.parameters, term.variable_index)
+                push!(params, term)
             else
                 error("Objective function uses a variable that is not in the model")
             end
         end
         param_constant = 0
-        for j in params
-            param_constant += j.coefficient * model.parameters[j.variable_index]
+        for param in params
+            param_constant += param.coefficient * model.parameters[param.variable_index]
         end
         fvar = MOI.ScalarAffineFunction(vars, f.constant + param_constant)
         co = MOI.set(model.optimizer, attr, fvar)
@@ -436,7 +484,7 @@ function MOI.get(optimizer::ParametricOptimizer, ::MOI.SolverName)
 end
 
 function MOI.add_constraint(model::ParametricOptimizer, f::MOI.VectorOfVariables, set::MOI.AbstractVectorSet) where T   
-    if any(haskey(model.parameters, f.variables) for i = 1:length(f.variables))
+    if function_has_parameters(model, f)
         error("VectorOfVariables does not allow parameters")
     else
         return MOI.add_constraint(model.optimizer, f, set)
@@ -444,7 +492,7 @@ function MOI.add_constraint(model::ParametricOptimizer, f::MOI.VectorOfVariables
 end
 
 function MOI.add_constraint(model::ParametricOptimizer, f::MOI.VectorAffineFunction{T}, set::MOI.AbstractVectorSet) where T   
-    if any(haskey(model.parameters, f.terms[i].variable_index) for i = 1:length(f.terms))
+    if function_has_parameters(model, f)
         error("VectorAffineFunction does not allow parameters")
     else
         return MOI.add_constraint(model.optimizer, f, set)
@@ -453,20 +501,15 @@ end
 
 function MOI.add_constraint(model::ParametricOptimizer, f::MOI.ScalarQuadraticFunction{T}, set::MOI.AbstractScalarSet) where T   
     
-    if (!any(haskey(model.parameters, f.affine_terms[i].variable_index) for i = 1:length(f.affine_terms)) && 
-        !any(haskey(model.parameters, f.quadratic_terms[j].variable_index_1) for j = 1:length(f.quadratic_terms)) &&
-        !any(haskey(model.parameters, f.quadratic_terms[j].variable_index_2) for j = 1:length(f.quadratic_terms)))
-
+    if !function_has_parameters(model, f)
         return MOI.add_constraint(model.optimizer, f, set) 
-
     else
      
         quad_params = MOI.ScalarQuadraticTerm{T}[] #outside declaration so it has default value
         quad_aff_vars = MOI.ScalarQuadraticTerm{T}[] #outside declaration so it has default value; parameter as variable_index_1
         aux_variables_associated_to_parameters =  MOI.VariableIndex[] #outside declaration so it has default value
 
-        if any(haskey(model.parameters, f.quadratic_terms[i].variable_index_1) for i = 1:length(f.quadratic_terms)) ||
-            any(haskey(model.parameters, f.quadratic_terms[i].variable_index_2) for i = 1:length(f.quadratic_terms)) 
+        if function_quadratic_terms_has_parameters(model, f.quadratic_terms)
             
             quad_terms = MOI.ScalarQuadraticTerm{T}[]
             
@@ -505,7 +548,7 @@ function MOI.add_constraint(model::ParametricOptimizer, f::MOI.ScalarQuadraticFu
         aff_params = MOI.ScalarAffineTerm{T}[] #outside declaration so it has default value
         variables_associated_to_parameters =  MOI.ScalarAffineTerm{T}[] #outside declaration so it has default value
 
-        if any(haskey(model.parameters, f.affine_terms[i].variable_index) for i = 1:length(f.affine_terms))
+        if function_affine_terms_has_parameters(model, f.affine_terms)
 
             aff_vars = MOI.ScalarAffineTerm{T}[]
 
@@ -595,10 +638,7 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.ObjectiveFunction, f::MOI
     model.quadratic_objective_cache_pc = Array{MOI.ScalarQuadraticTerm{T},1}()
 
 
-    if (!any(haskey(model.parameters, f.affine_terms[i].variable_index) for i = 1:length(f.affine_terms)) && 
-        !any(haskey(model.parameters, f.quadratic_terms[j].variable_index_1) for j = 1:length(f.quadratic_terms)) &&
-        !any(haskey(model.parameters, f.quadratic_terms[j].variable_index_2) for j = 1:length(f.quadratic_terms)))
-        
+    if !function_has_parameters(model, f)
         MOI.set(model.optimizer, attr, f) 
         return
     else
@@ -607,32 +647,28 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.ObjectiveFunction, f::MOI
         quad_aff_vars = MOI.ScalarQuadraticTerm{T}[] #outside declaration so it has default value; parameter as variable_index_1
         aux_variables_associated_to_parameters =  MOI.VariableIndex[] #outside declaration so it has default value
 
-        if (any(haskey(model.parameters, f.quadratic_terms[i].variable_index_1) for i = 1:length(f.quadratic_terms)) ||
-             any(haskey(model.parameters, f.quadratic_terms[i].variable_index_2) for i = 1:length(f.quadratic_terms)))
+        if function_quadratic_terms_has_parameters(model, f.quadratic_terms)
             
             quad_terms = MOI.ScalarQuadraticTerm{T}[]  
 
-            for i in f.quadratic_terms
-                if haskey(model.variables, i.variable_index_1) && haskey(model.variables, i.variable_index_2)
-                    push!(quad_terms, i) # if there are only variables, it remains a quadratic term
+            for term in f.quadratic_terms
+                if haskey(model.variables, term.variable_index_1) && haskey(model.variables, term.variable_index_2)
+                    push!(quad_terms, term) # if there are only variables, it remains a quadratic term
 
-                elseif haskey(model.parameters, i.variable_index_1) && haskey(model.variables, i.variable_index_2)
-                    # This is the case when i.variable_index_1 is a parameter and i.variable_index_2 is a variable.
+                elseif haskey(model.parameters, term.variable_index_1) && haskey(model.variables, term.variable_index_2)
+                    # This is the case when term.variable_index_1 is a parameter and term.variable_index_2 is a variable.
                     # Thus, it creates an affine term. Convention: param as 1, var as 2
-                    aux = MOI.ScalarQuadraticTerm(i.coefficient, i.variable_index_1, i.variable_index_2)
-                    push!(quad_aff_vars, aux)
-                    push!(aux_variables_associated_to_parameters, i.variable_index_2)
+                    push!(quad_aff_vars, MOI.ScalarQuadraticTerm(term.coefficient, term.variable_index_1, term.variable_index_2))
+                    push!(aux_variables_associated_to_parameters, term.variable_index_2)
 
-                elseif haskey(model.variables, i.variable_index_1) && haskey(model.parameters, i.variable_index_2)
+                elseif haskey(model.variables, term.variable_index_1) && haskey(model.parameters, term.variable_index_2)
                     # Check convention defined above
-                    aux = MOI.ScalarQuadraticTerm(i.coefficient, i.variable_index_2, i.variable_index_1)
-                    push!(quad_aff_vars, aux)
-                    push!(aux_variables_associated_to_parameters, i.variable_index_1)
+                    push!(quad_aff_vars, MOI.ScalarQuadraticTerm(term.coefficient, term.variable_index_2, term.variable_index_1))
+                    push!(aux_variables_associated_to_parameters, term.variable_index_1)
 
-                elseif haskey(model.parameters, i.variable_index_1) && haskey(model.parameters, i.variable_index_2)
+                elseif haskey(model.parameters, term.variable_index_1) && haskey(model.parameters, term.variable_index_2)
                     # This is the case where both variable_index_1,2 are actually parameters
-                    aux = MOI.ScalarQuadraticTerm(i.coefficient, i.variable_index_1, i.variable_index_2)
-                    push!(quad_params, aux)
+                    push!(quad_params, MOI.ScalarQuadraticTerm(term.coefficient, term.variable_index_1, term.variable_index_2))
 
                 else
                     error("Constraint uses a variable that is not in the model")
@@ -647,18 +683,18 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.ObjectiveFunction, f::MOI
         aff_params = MOI.ScalarAffineTerm{T}[] #outside declaration so it has default value
         variables_associated_to_parameters =  MOI.ScalarAffineTerm{T}[] #outside declaration so it has default value
 
-        if any(haskey(model.parameters, f.affine_terms[i].variable_index) for i = 1:length(f.affine_terms))     
+        if function_affine_terms_has_parameters(model, f.affine_terms)
 
             aff_vars = MOI.ScalarAffineTerm{T}[]
 
-            for i in f.affine_terms
-                if haskey(model.variables, i.variable_index)
-                    push!(aff_vars, i)
-                    if i.variable_index in aux_variables_associated_to_parameters
-                        push!(variables_associated_to_parameters, i)
+            for term in f.affine_terms
+                if haskey(model.variables, term.variable_index)
+                    push!(aff_vars, term)
+                    if term.variable_index in aux_variables_associated_to_parameters
+                        push!(variables_associated_to_parameters, term)
                     end
-                elseif haskey(model.parameters, i.variable_index)
-                    push!(aff_params, i)
+                elseif haskey(model.parameters, term.variable_index)
+                    push!(aff_params, term)
                 else
                     error("Constraint uses a variable that is not in the model")
                 end
@@ -670,21 +706,20 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.ObjectiveFunction, f::MOI
 
         aff_terms = MOI.ScalarAffineTerm{T}[]
 
-        for i in quad_aff_vars
-            aux = MOI.ScalarAffineTerm(i.coefficient * model.parameters[i.variable_index_1], i.variable_index_2)
-            push!(aff_terms, aux)
+        for variable in quad_aff_vars
+            push!(aff_terms, MOI.ScalarAffineTerm(variable.coefficient * model.parameters[variable.variable_index_1], variable.variable_index_2))
         end
 
         aff_terms = vcat(aff_terms, aff_vars)
 
         const_term = f.constant
 
-        for j in aff_params
-            const_term += j.coefficient * model.parameters[j.variable_index]
+        for param in aff_params
+            const_term += param.coefficient * model.parameters[param.variable_index]
         end
 
-        for j in quad_params
-            const_term += j.coefficient * model.parameters[j.variable_index_1] * model.parameters[j.variable_index_2]
+        for param in quad_params
+            const_term += param.coefficient * model.parameters[param.variable_index_1] * model.parameters[param.variable_index_2]
         end
 
         if !isempty(quad_terms)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
-using Test, ParametricOptInterface, MathOptInterface, GLPK, Ipopt, JuMP
+using Test 
+using ParametricOptInterface
+using MathOptInterface
+using GLPK
+using Ipopt
+using JuMP
 
 const POI = ParametricOptInterface
 const MOI = MathOptInterface


### PR DESCRIPTION
Current comparison against master
```

========== Results ==========

add_constraint
BenchmarkTools.TrialJudgement: 
  time:   -10.68% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_sqf_2
BenchmarkTools.TrialJudgement: 
  time:   -8.57% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variable_constraints
BenchmarkTools.TrialJudgement: 
  time:   -4.12% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variables
BenchmarkTools.TrialJudgement: 
  time:   -4.23% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variable
BenchmarkTools.TrialJudgement: 
  time:   -2.10% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constrained_variable
BenchmarkTools.TrialJudgement: 
  time:   -0.71% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_saf_3
BenchmarkTools.TrialJudgement: 
  time:   -2.90% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_svf
BenchmarkTools.TrialJudgement: 
  time:   -6.41% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_saf_1
BenchmarkTools.TrialJudgement: 
  time:   -22.56% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_sqf_3
BenchmarkTools.TrialJudgement: 
  time:   -38.77% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variable_constraint
BenchmarkTools.TrialJudgement: 
  time:   -0.80% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_sqf_1
BenchmarkTools.TrialJudgement: 
  time:   +1.92% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraints
BenchmarkTools.TrialJudgement: 
  time:   +0.04% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_saf_2
BenchmarkTools.TrialJudgement: 
  time:   -6.65% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

```