### PR TITLE
Clever indexing

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -27,7 +27,7 @@ MOI.Benchmarks.@add_benchmark function add_constraint_saf_1(new_model)
     y, _ = MOI.add_constrained_variable(model, POI.Parameter(0))
     for _ in 1:10_000
         MOI.add_constraint(model, 
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(102), [x[1:100]; y; y]), 0.0), 
+            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(103), [x[i]; x[1:100]; y; y]), 0.0), 
             MOI.GreaterThan(1.0)
         )
     end

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -25,7 +25,7 @@ MOI.Benchmarks.@add_benchmark function add_constraint_saf_1(new_model)
     model = new_model()
     x = MOI.add_variables(model, 10_000)
     y, _ = MOI.add_constrained_variable(model, POI.Parameter(0))
-    for _ in 1:10_000
+    for i in 1:10_000
         MOI.add_constraint(model, 
             MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(103), [x[i]; x[1:100]; y; y]), 0.0), 
             MOI.GreaterThan(1.0)

--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -152,7 +152,7 @@ function MOI.empty!(model::ParametricOptimizer{T}) where T
 end
 
 function MOI.set(model::ParametricOptimizer, attr::MOI.VariableName, v::MOI.VariableIndex, name::String)
-    if haskey(model.parameters, v)
+    if is_parameter_in_model(model, v)
         model.parameters_name[v] = name
     else
         return MOI.set(model.optimizer, attr, v, name)
@@ -160,7 +160,7 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.VariableName, v::MOI.Vari
 end
 
 function MOI.get(model::ParametricOptimizer, attr::MOI.VariableName, v::MOI.VariableIndex)
-    if haskey(model.parameters, v)
+    if is_parameter_in_model(model, v)
         return model.parameters_name[v]
     else
         return MOI.get(model.optimizer, attr, v)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,79 @@
+next_variable_index!(model::ParametricOptimizer) = model.last_variable_index_added += 1
+next_parameter_index!(model::ParametricOptimizer) = model.last_parameter_index_added += 1
+
+function is_parameter_in_model(model::ParametricOptimizer, v::MOI.VariableIndex)
+    return PARAMETER_INDEX_THRESHOLD < v.value <= model.last_parameter_index_added 
+end
+
+function is_variable_in_model(model::ParametricOptimizer, v::MOI.VariableIndex)
+    return 0 < v.value <= model.last_variable_index_added 
+end
+
+function function_has_parameters(model::ParametricOptimizer, f::MOI.ScalarAffineFunction{T}) where T
+    for term in f.terms
+        if is_parameter_in_model(model, term.variable_index)
+            return true
+        end
+    end
+    return false
+end
+function function_has_parameters(model::ParametricOptimizer, f::MOI.VectorOfVariables)
+    for variable in f.variables
+        if is_parameter_in_model(model, variable)
+            return true
+        end
+    end
+    return false
+end
+function function_has_parameters(model::ParametricOptimizer, f::MOI.VectorAffineFunction{T}) where T
+    for term in f.terms
+        if is_parameter_in_model(model, term.variable_index)
+            return true
+        end
+    end
+    return false
+end
+function function_has_parameters(model::ParametricOptimizer, f::MOI.ScalarQuadraticFunction{T}) where T
+    return function_affine_terms_has_parameters(model, f.affine_terms) ||
+           function_quadratic_terms_has_parameters(model, f.quadratic_terms)
+end
+function function_affine_terms_has_parameters(model::ParametricOptimizer, affine_terms::Vector{MOI.ScalarAffineTerm{T}}) where T
+    for term in affine_terms
+        if is_parameter_in_model(model, term.variable_index)
+            return true
+        end
+    end
+    return false
+end
+function function_quadratic_terms_has_parameters(model::ParametricOptimizer, quadratic_terms::Vector{MOI.ScalarQuadraticTerm{T}}) where T
+    for term in quadratic_terms
+        if is_parameter_in_model(model, term.variable_index_1) || is_parameter_in_model(model, term.variable_index_2)
+            return true
+        end
+    end
+    return false
+end
+
+function separate_variables_from_parameters(model::ParametricOptimizer, terms::Vector{MOI.ScalarAffineTerm{T}}) where T
+    vars = MOI.ScalarAffineTerm{T}[]
+    params = MOI.ScalarAffineTerm{T}[]
+
+    for term in terms
+        if is_variable_in_model(model, term.variable_index)
+            push!(vars, term)
+        elseif is_parameter_in_model(model, term.variable_index)
+            push!(params, term)
+        else
+            error("Constraint uses a variable that is not in the model")
+        end
+    end
+    return vars, params
+end
+
+function calculate_param_constant(model::ParametricOptimizer, params::Vector{MOI.ScalarAffineTerm{T}}) where T
+    param_constant = zero(T)
+    for param in params
+        param_constant += param.coefficient * model.parameters[param.variable_index]
+    end
+    return param_constant
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,26 +54,20 @@ function function_quadratic_terms_has_parameters(model::ParametricOptimizer, qua
     return false
 end
 
-function separate_variables_from_parameters(model::ParametricOptimizer, terms::Vector{MOI.ScalarAffineTerm{T}}) where T
+function separate_variables_from_parameters_and_calculate_param_constant(model::ParametricOptimizer, terms::Vector{MOI.ScalarAffineTerm{T}}) where T
     vars = MOI.ScalarAffineTerm{T}[]
     params = MOI.ScalarAffineTerm{T}[]
+    param_constant = zero(T)
 
     for term in terms
         if is_variable_in_model(model, term.variable_index)
             push!(vars, term)
         elseif is_parameter_in_model(model, term.variable_index)
             push!(params, term)
+            param_constant += term.coefficient * model.parameters[term.variable_index]
         else
             error("Constraint uses a variable that is not in the model")
         end
     end
-    return vars, params
-end
-
-function calculate_param_constant(model::ParametricOptimizer, params::Vector{MOI.ScalarAffineTerm{T}}) where T
-    param_constant = zero(T)
-    for param in params
-        param_constant += param.coefficient * model.parameters[param.variable_index]
-    end
-    return param_constant
+    return vars, params, param_constant
 end

--- a/test/production_problem_test.jl
+++ b/test/production_problem_test.jl
@@ -28,7 +28,7 @@
     MOI.add_constraint(optimizer, cons2, MOI.LessThan(b2))
 
     @test cons1.terms[1].coefficient == 2
-    @test cons2.terms[3].variable_index == MOI.VariableIndex(5)
+    @test POI.is_parameter_in_model(optimizer, cons2.terms[3].variable_index)
 
     obj_func = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([c[1], c[2], 1.0], [x[1], x[2], w]), 0.0)
     MOI.set(optimizer, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), obj_func)


### PR DESCRIPTION
We made checking if a MOI.VariableIndex is a variable or a parameter faster and made some better function barriers.

I think that these reports are not too reliable, depending on the run they give opposite results... Anyways, here they are


========== Results ==========

add_constraint
BenchmarkTools.TrialJudgement: 
  time:   -1.75% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_sqf_2
BenchmarkTools.TrialJudgement: 
  time:   +13.86% => regression (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variable_constraints
BenchmarkTools.TrialJudgement: 
  time:   -24.59% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variables
BenchmarkTools.TrialJudgement: 
  time:   -13.33% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variable
BenchmarkTools.TrialJudgement: 
  time:   -7.22% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constrained_variable
BenchmarkTools.TrialJudgement: 
  time:   -13.35% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_saf_3
BenchmarkTools.TrialJudgement: 
  time:   -3.57% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_svf
BenchmarkTools.TrialJudgement: 
  time:   -18.28% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_saf_1
BenchmarkTools.TrialJudgement: 
  time:   -10.47% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_sqf_3
BenchmarkTools.TrialJudgement: 
  time:   +21.67% => regression (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_variable_constraint
BenchmarkTools.TrialJudgement: 
  time:   -19.42% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_sqf_1
BenchmarkTools.TrialJudgement: 
  time:   -16.19% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraints
BenchmarkTools.TrialJudgement: 
  time:   -7.07% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)

add_constraint_saf_2
BenchmarkTools.TrialJudgement: 
  time:   -1.19% => invariant (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)