### PR TITLE
Add POI.Parameters

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -73,6 +73,12 @@ To change a given parameter's value, access its `ConstraintIndex` and set it to 
 MOI.set(optimizer, MOI.ConstraintSet(), cy, POI.Parameter(2.0))
 ```
 
+as an alternative one can also use the custom MOI attribute `ParameterValue`
+
+```julia
+MOI.set(optimizer, POI.ParameterValue(), y, 2.0)
+```
+
 ### Retrieving the dual of a parameter
 
 Given an optimized model, one can calculate the dual associated to a parameters, **as long as it is an additive term in the constraints or objective**.
@@ -80,4 +86,18 @@ One can do so by getting the `MOI.ConstraintDual` attribute of the paraameter's 
 
 ```julia
 MOI.get(optimizer, MOI.ConstraintDual, cy)
+```
+
+as an alternative one can also use the custom MOI attribute `ParameterValue`
+
+```julia
+MOI.get(optimizer, POI.ParameterDual(), y)
+```
+
+## API
+
+```@docs
+POI.Parameter
+POI.Parameters
+POI.ParametricOptimizer
 ```

--- a/test/production_problem_test.jl
+++ b/test/production_problem_test.jl
@@ -90,6 +90,98 @@
    
 end
 
+@testset "Production Problem with Parameters as VectorSet" begin
+    optimizer = POI.ParametricOptimizer(GLPK.Optimizer())
+    
+    c = [4.0, 3.0]
+    A1 = [2.0, 1.0, 1.0]
+    A2 = [1.0, 2.0, 1.0]
+    b1 = 4.0
+    b2 = 4.0
+
+    x = MOI.add_variables(optimizer, length(c))
+
+    @test typeof(x[1]) == MOI.VariableIndex
+
+    vars, cons = MOI.add_constrained_variables(optimizer, POI.Parameters(zeros(3)))
+    w, y, z = vars
+    cw, cy, cz = cons
+
+    @test MOI.get(optimizer, MOI.VariablePrimal(), w) == 0
+
+    for x_i in x
+        MOI.add_constraint(optimizer, MOI.SingleVariable(x_i), MOI.GreaterThan(0.0))
+    end
+
+    cons1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(A1, [x[1], x[2], y]), 0.0)
+    MOI.add_constraint(optimizer, cons1, MOI.LessThan(b1))
+
+    cons2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(A2, [x[1], x[2], z]), 0.0)
+    MOI.add_constraint(optimizer, cons2, MOI.LessThan(b2))
+
+    @test cons1.terms[1].coefficient == 2
+    @test POI.is_parameter_in_model(optimizer, cons2.terms[3].variable_index)
+
+    obj_func = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([c[1], c[2], 3.0], [x[1], x[2], w]), 0.0)
+    MOI.set(optimizer, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), obj_func)
+    MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+
+    MOI.optimize!(optimizer)
+
+    MOI.get(optimizer, MOI.TerminationStatus())
+
+    MOI.get(optimizer, MOI.PrimalStatus())
+
+    @test isapprox.(MOI.get(optimizer, MOI.ObjectiveValue()), 28/3, atol = ATOL)
+    @test isapprox.(MOI.get(optimizer, MOI.VariablePrimal(), x[1]), 4/3, atol = ATOL)
+    @test isapprox.(MOI.get(optimizer, MOI.VariablePrimal(), x[2]), 4/3, atol = ATOL)
+
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cy), -5/3, atol = ATOL)
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cz), -2/3, atol = ATOL)
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cw), 3.0, atol = ATOL)
+
+    MOI.get(optimizer, MOI.VariablePrimal(), w)
+    MOI.get(optimizer, MOI.VariablePrimal(), y)
+    MOI.get(optimizer, MOI.VariablePrimal(), z)
+
+    MOI.set(optimizer, MOI.ConstraintSet(), cw, POI.Parameter(2.0))
+    MOI.set(optimizer, MOI.ConstraintSet(), cy, POI.Parameter(1.0))
+    MOI.set(optimizer, MOI.ConstraintSet(), cz, POI.Parameter(1.0))
+
+    MOI.optimize!(optimizer)
+
+    @test MOI.get(optimizer, MOI.VariablePrimal(), w) == 2.0
+    @test MOI.get(optimizer, MOI.VariablePrimal(), y) == 1.0
+    @test MOI.get(optimizer, MOI.VariablePrimal(), z) == 1.0
+    
+    @test isapprox.(MOI.get(optimizer, MOI.ObjectiveValue()), 13.0, atol = ATOL)
+    @test MOI.get.(optimizer, MOI.VariablePrimal(), x) == [1.0, 1.0]
+
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cy), -5/3, atol = ATOL)
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cz), -2/3, atol = ATOL)
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cw), 3.0, atol = ATOL)
+
+    MOI.set(optimizer, MOI.ConstraintSet(), cw, POI.Parameter(0.0))
+    
+    MOI.optimize!(optimizer)
+
+    @test MOI.get(optimizer, MOI.VariablePrimal(), w) == 0.0
+    @test MOI.get(optimizer, MOI.VariablePrimal(), y) == 1.0
+    @test MOI.get(optimizer, MOI.VariablePrimal(), z) == 1.0
+    @test isapprox.(MOI.get(optimizer, MOI.ObjectiveValue()), 7, atol = ATOL)
+    @test MOI.get.(optimizer, MOI.VariablePrimal(), x) == [1.0, 1.0]
+
+
+    MOI.set(optimizer, MOI.ConstraintSet(), cy, POI.Parameter(-5.0))
+    MOI.optimize!(optimizer)
+    @test isapprox.(MOI.get(optimizer, MOI.ObjectiveValue()), 12.0, atol = ATOL)
+    @test MOI.get.(optimizer, MOI.VariablePrimal(), x) == [3.0, 0.0]
+
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cy), 0, atol = ATOL)
+    @test isapprox(MOI.get(optimizer, MOI.ConstraintDual(), cz), -4, atol = ATOL)
+
+end
+
 
 @testset "Production Problem variation on parameters for duals" begin
     optimizer = POI.ParametricOptimizer(GLPK.Optimizer())


### PR DESCRIPTION
This is a step towards solving #20 
Now this works
```julia
optimizer = POI.ParametricOptimizer(GLPK.Optimizer())

model = direct_model(optimizer)

@variable(model, x[i=1:2] >= 0)

@variable(model, y[i=1:3] in POI.Parameters(zeros(3)))

@constraint(model, 2*x[1] + x[2] + y[1] <= 4)
@constraint(model, 1*x[1] + 2*x[2] + y[3] <= 4)

@objective(model, Max, 4*x[1] + 3*x[2] + y[2])

optimize!(model)
```

but this does not
```julia
model = Model(() -> POI.ParametricOptimizer(GLPK.Optimizer()));

@variable(model, x[i=1:2] >= 0);
@variable(model, y[i=1:3] in POI.Parameters(zeros(3)))

@constraint(model, 2*x[1] + x[2] + y[1] <= 4)
@constraint(model, 1*x[1] + 2*x[2] + y[3] <= 4)

@objective(model, Max, 4*x[1] + 3*x[2] + y[2])

optimize!(model)
```
The model gives the following error:
```julia
ERROR: MathOptInterface.UnsupportedConstraint{MathOptInterface.VectorOfVariables, ParametricOptInterface.Parameters}: `MathOptInterface.VectorOfVariables`-in-`ParametricOptInterface.Parameters` constraint is not supported by the model.
Stacktrace:
  [1] bridge_type(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, GLPK.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}}}, S::Type{ParametricOptInterface.Parameters})
    @ MathOptInterface.Bridges C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Bridges\lazy_bridge_optimizer.jl:423
  [2] concrete_bridge_type
    @ C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Bridges\Variable\bridge.jl:248 [inlined]
  [3] add_constrained_variables(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, GLPK.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}}}, set::ParametricOptInterface.Parameters)
    @ MathOptInterface.Bridges C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Bridges\bridge_optimizer.jl:1646
  [4] copy_vector_of_variables(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, GLPK.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, idxmap::MathOptInterface.Utilities.IndexMap, S::Type{ParametricOptInterface.Parameters}, copy_constrained_variables::typeof(MathOptInterface.add_constrained_variables))
    @ MathOptInterface.Utilities C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Utilities\copy.jl:335
  [5] try_constrain_variables_on_creation(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, GLPK.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, idxmap::MathOptInterface.Utilities.IndexMap, copy_constrained_variables::typeof(MathOptInterface.add_constrained_variables), copy_constrained_variable::typeof(MathOptInterface.add_constrained_variable))
    @ MathOptInterface.Utilities C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Utilities\copy.jl:619
  [6] default_copy_to(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, GLPK.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}}}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, copy_names::Bool, filter_constraints::Nothing)
    @ MathOptInterface.Utilities C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Utilities\copy.jl:691
  [7] #automatic_copy_to#127
    @ C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Utilities\copy.jl:24 [inlined]
  [8] #copy_to#4
    @ C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Bridges\bridge_optimizer.jl:401 [inlined]
  [9] attach_optimizer(model::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}})
    @ MathOptInterface.Utilities C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Utilities\cachingoptimizer.jl:185
 [10] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}})
    @ MathOptInterface.Utilities C:\Users\guilhermebodin\.julia\packages\MathOptInterface\YDdD3\src\Utilities\cachingoptimizer.jl:248
 [11] optimize!(model::Model, optimizer_factory::Nothing; bridge_constraints::Bool, ignore_optimize_hook::Bool, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ JuMP C:\Users\guilhermebodin\.julia\packages\JuMP\Xrr7O\src\optimizer_interface.jl:185
 [12] optimize! (repeats 2 times)
    @ C:\Users\guilhermebodin\.julia\packages\JuMP\Xrr7O\src\optimizer_interface.jl:157 [inlined]
 [13] top-level scope
    @ REPL[43]:1
```