### PR TITLE
missing methods for NLP

### DIFF
--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -144,6 +144,13 @@ end
 
 MOI.supports(model::ParametricOptimizer, attr::MOI.NLPBlock) = MOI.supports(model.optimizer, attr)
 
+function MOI.supports(model::ParametricOptimizer,
+    attr::MOI.VariablePrimalStart,
+    ::Type{T},
+) where T
+    return MOI.supports(model.optimizer, attr, T)
+end
+
 function MOI.empty!(model::ParametricOptimizer{T}) where T
     MOI.empty!(model.optimizer)
     empty!(model.parameters)

--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -142,7 +142,44 @@ function MOI.supports(
     return MOI.supports(model.optimizer, attr)
 end
 
+
 MOI.supports(model::ParametricOptimizer, attr::MOI.NLPBlock) = MOI.supports(model.optimizer, attr)
+MOI.supports(model::ParametricOptimizer, attr::MOI.NLPBlockDualStart) = MOI.supports(model.optimizer, attr)
+
+function MOI.set(model::ParametricOptimizer, attr::MOI.NLPBlock, args::MOI.NLPBlockData)
+    return MOI.set(model.optimizer, attr, args)
+end
+
+function MOI.set(
+    model::ParametricOptimizer,
+    attr::MOI.NLPBlockDualStart,
+    values::Union{Nothing,Vector},
+)
+    MOI.set(model.optimizer, attr, values)
+    return
+end
+
+function MOI.get(model::ParametricOptimizer, attr::MOI.NLPBlockDualStart)
+    return MOI.get(model.optimizer, attr)
+end
+
+function MOI.get(model::ParametricOptimizer, attr::MOI.NLPBlockDual)
+    return MOI.get(model.optimizer, attr)
+end
+
+function MOI.set(
+    model::ParametricOptimizer,
+    ::MOI.ObjectiveFunction,
+    func::Union{
+        MOI.SingleVariable,
+        MOI.ScalarAffineFunction,
+        MOI.ScalarQuadraticFunction,
+    },
+)
+    check_inbounds(model, func)
+    model.objective = func
+    return
+end
 
 function MOI.supports(model::ParametricOptimizer,
     attr::MOI.VariablePrimalStart,
@@ -649,8 +686,15 @@ function MOI.set(model::ParametricOptimizer, attr::MOI.ObjectiveFunction, f::MOI
     end
 end
 
-function MOI.copy_to(model::ParametricOptimizer, src::MathOptInterface.ModelLike; kws...)
-    return MOI.copy_to(model.optimizer, src; kws...)
+function MOI.Utilities.supports_default_copy_to(
+    model::ParametricOptimizer,
+    copy_names::Bool,
+)
+    return !copy_names
+end
+
+function MOI.copy_to(dest::ParametricOptimizer, src::MOI.ModelLike; kwargs...)
+    return MOI.Utilities.automatic_copy_to(dest, src; kwargs...)
 end
 
 function MOI.optimize!(model::ParametricOptimizer)

--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -201,6 +201,10 @@ function MOI.get(model::ParametricOptimizer, ::MOI.NumberOfVariables)
     return length(model.parameters) + length(model.variables)
 end
 
+function MOI.get(model::ParametricOptimizer, attr::MOI.ListOfConstraints)
+    return MOI.get(model.optimizer, attr)
+end
+
 function MOI.supports(model::ParametricOptimizer, attr::MOI.ConstraintName, tp::Type{<:MOI.ConstraintIndex})
     return MOI.supports(model.optimizer, attr, tp)
 end

--- a/test/nlp_tests.jl
+++ b/test/nlp_tests.jl
@@ -1,0 +1,11 @@
+@testset "JuMP NLP models" begin
+    @test MOI.supports(POI.ParametricOptimizer(Ipopt.Optimizer()), MOI.NLPBlock())
+
+    model = Model(() -> POI.ParametricOptimizer(Ipopt.Optimizer()))
+
+    @variable(model, x[i=1:2] >= 0)
+    @variable(model, y in POI.Parameter(10))
+    @constraint(model, sum(x) + y >= 0)
+    @NLobjective(model, Min, x[1]^2 + x[2]^2)
+    optimize!(model)
+end

--- a/test/nlp_tests.jl
+++ b/test/nlp_tests.jl
@@ -3,21 +3,38 @@
 
     model = Model(() -> POI.ParametricOptimizer(Ipopt.Optimizer()))
 
+    y = @variable(model, y in POI.Parameter(10))
     @variable(model, x[i=1:2] >= 0)
-    @variable(model, y in POI.Parameter(10))
-    @constraint(model, sum(x) + y >= 0)
+    @constraint(model, x[1] >= y)
+    @constraint(model, sum(x) + 2*y >= 0)
     @NLobjective(model, Min, x[1]^2 + x[2]^2)
     optimize!(model)
+    @test isapprox(JuMP.value(x[1]), JuMP.value(y))
+
+    MOI.set(model, POI.ParameterValue(), y, 20.0)
+    optimize!(model)
+    @test isapprox(JuMP.value(x[1]), 20.0)
+    @test isapprox(JuMP.value(y), 20.0)
+
+    model = Model(() -> POI.ParametricOptimizer(Ipopt.Optimizer()))
+
+    @variable(model, y in POI.Parameter(10))
+    @variable(model, x[i=1:2] >= 0)
+    @constraint(model, x[1] >= y)
+    @NLconstraint(model, sum(x[i]^2 for i in 1:2) >= 0)
+    @NLobjective(model, Min, x[1]^2 + x[2]^2)
+    optimize!(model)
+    @test isapprox(JuMP.value(x[1]), JuMP.value(y))
 end
 
 @testset "JuMP direct mode NLP models" begin
-    @test MOI.supports(POI.ParametricOptimizer(Ipopt.Optimizer()), MOI.NLPBlock())
-
-    optimizer = POI.ParametricOptimizer(Ipopt.Optimizer())
-    model = direct_model(optimizer)
-    @variable(model, x[i=1:2] >= 0)
-    @variable(model, y in POI.Parameter(10))
-    @constraint(model, sum(x) + y >= 0)
-    @NLobjective(model, Min, x[1]^2 + x[2]^2)
-    optimize!(model)
+    # Requires https://github.com/jump-dev/Ipopt.jl/issues/280
+    #@test MOI.supports(POI.ParametricOptimizer(Ipopt.Optimizer()), MOI.NLPBlock())
+    #optimizer = POI.ParametricOptimizer(Ipopt.Optimizer())
+    #model = direct_model(optimizer)
+    #@variable(model, x[i=1:2] >= 0)
+    #@variable(model, y in POI.Parameter(10))
+    #@constraint(model, sum(x) + y >= 0)
+    #@NLobjective(model, Min, x[1]^2 + x[2]^2)
+    #optimize!(model)
 end

--- a/test/nlp_tests.jl
+++ b/test/nlp_tests.jl
@@ -9,3 +9,15 @@
     @NLobjective(model, Min, x[1]^2 + x[2]^2)
     optimize!(model)
 end
+
+@testset "JuMP direct mode NLP models" begin
+    @test MOI.supports(POI.ParametricOptimizer(Ipopt.Optimizer()), MOI.NLPBlock())
+
+    optimizer = POI.ParametricOptimizer(Ipopt.Optimizer())
+    model = direct_model(optimizer)
+    @variable(model, x[i=1:2] >= 0)
+    @variable(model, y in POI.Parameter(10))
+    @constraint(model, sum(x) + y >= 0)
+    @NLobjective(model, Min, x[1]^2 + x[2]^2)
+    optimize!(model)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test 
+using Test
 using ParametricOptInterface
 using MathOptInterface
 using GLPK
@@ -15,4 +15,4 @@ include("production_problem_test.jl")
 include("basic_tests.jl")
 include("quad_tests.jl")
 include("jump_tests.jl")
-
+include("nlp_tests.jl")


### PR DESCRIPTION
Attempt to address #43 however it throws an error of support for the ParameterSet 

I added a test to the repo to reproduce. 

P.S. sorry for all the white space changes, my IDE removed all the trailing white space. 

```julia 
ERROR: MathOptInterface.UnsupportedConstraint{MathOptInterface.SingleVariable, ParametricOptInterface.Parameter}: `MathOptInterface.SingleVariable`-in-`ParametricOptInterface.Parameter` constraint is not supported by the model.
Stacktrace:
  [1] correct_throw_add_constraint_error_fallback(model::Ipopt.Optimizer, func::MathOptInterface.SingleVariable, set::ParametricOptInterface.Parameter; error_if_supported::MathOptInterface.AddConstraintNotAllowed{MathOptInterface.SingleVariable, ParametricOptInterface.Parameter})
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/constraints.jl:199
  [2] correct_throw_add_constraint_error_fallback(model::Ipopt.Optimizer, func::MathOptInterface.SingleVariable, set::ParametricOptInterface.Parameter)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/constraints.jl:196
  [3] throw_add_constraint_error_fallback(model::Ipopt.Optimizer, func::MathOptInterface.SingleVariable, set::ParametricOptInterface.Parameter; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/constraints.jl:148
  [4] throw_add_constraint_error_fallback(model::Ipopt.Optimizer, func::MathOptInterface.SingleVariable, set::ParametricOptInterface.Parameter)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/constraints.jl:148
  [5] add_constraint(model::Ipopt.Optimizer, func::MathOptInterface.SingleVariable, set::ParametricOptInterface.Parameter)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/constraints.jl:136
  [6] _broadcast_getindex_evalf
    @ ./broadcast.jl:648 [inlined]
  [7] _broadcast_getindex
    @ ./broadcast.jl:621 [inlined]
  [8] getindex
    @ ./broadcast.jl:575 [inlined]
  [9] copy
    @ ./broadcast.jl:922 [inlined]
 [10] materialize
    @ ./broadcast.jl:883 [inlined]
 [11] add_constraints(model::Ipopt.Optimizer, funcs::Vector{MathOptInterface.SingleVariable}, sets::Vector{ParametricOptInterface.Parameter})
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/constraints.jl:229
 [12] copy_constraints(dest::Ipopt.Optimizer, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, idxmap::MathOptInterface.Utilities.IndexMap, cis_src::Vector{MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable, ParametricOptInterface.Parameter}}, filter_constraints::Nothing)
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/copy.jl:419
 [13] copy_constraints(dest::Ipopt.Optimizer, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, idxmap::MathOptInterface.Utilities.IndexMap, cis_src::Vector{MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable, ParametricOptInterface.Parameter}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/copy.jl:409
 [14] pass_constraints(dest::Ipopt.Optimizer, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, copy_names::Bool, idxmap::MathOptInterface.Utilities.IndexMap, single_variable_types::Vector{DataType}, single_variable_indices::Vector{Vector{T} where T}, vector_of_variables_types::Vector{DataType}, vector_of_variables_indices::Vector{Any}, pass_cons::typeof(MathOptInterface.Utilities.copy_constraints), pass_attr::typeof(MathOptInterface.set); filter_constraints::Nothing)
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/copy.jl:502
 [15] default_copy_to(dest::Ipopt.Optimizer, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, copy_names::Bool, filter_constraints::Nothing)
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/copy.jl:714
 [16] default_copy_to
    @ ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/copy.jl:669 [inlined]
 [17] #copy_to#12
    @ ~/.julia/packages/Ipopt/vtrOr/src/MOI_wrapper.jl:261 [inlined]
 [18] #copy_to#5
    @ ~/.julia/dev/ParametricOptInterface/src/ParametricOptInterface.jl:642 [inlined]
 [19] attach_optimizer(model::MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, Ipopt.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/cachingoptimizer.jl:185
 [20] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, Ipopt.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/cachingoptimizer.jl:248
 [21] optimize!(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{ParametricOptInterface.ParametricOptimizer{Float64, Ipopt.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}}})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/YDdD3/src/Bridges/bridge_optimizer.jl:319
 [22] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/YDdD3/src/Utilities/cachingoptimizer.jl:252
 [23] optimize!(model::Model, optimizer_factory::Nothing; bridge_constraints::Bool, ignore_optimize_hook::Bool, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ JuMP ~/.julia/packages/JuMP/Xrr7O/src/optimizer_interface.jl:185
 [24] optimize! (repeats 2 times)
    @ ~/.julia/packages/JuMP/Xrr7O/src/optimizer_interface.jl:157 [inlined]
 [25] top-level scope
    @ REPL[79]:1
```