### PR TITLE
Fix misleading benchmarks

### DIFF
--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -35,9 +35,9 @@ version = "0.7.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "96b0bc6c52df76506efc8a441c6cf1adcb1babc4"
+git-tree-sha1 = "b153278a25dd42c65abbf4e62344f9d22e59191b"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.42.0"
+version = "3.43.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -139,9 +139,9 @@ version = "1.4.1"
 
 [[ParametricOptInterface]]
 deps = ["DataStructures", "MathOptInterface"]
-git-tree-sha1 = "4095982577e095178e37382c0a981218d035421f"
+git-tree-sha1 = "a5a7d207546a5148d59f0ec43b7475f586146e29"
 uuid = "0ce4ce61-57bf-432b-a095-efac525d185e"
-version = "0.3.0"
+version = "0.3.2"
 
 [[Parsers]]
 deps = ["Dates"]

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -1,3 +1,5 @@
+push!(LOAD_PATH, "../src")
+
 using MathOptInterface
 using ParametricOptInterface
 using BenchmarkTools
@@ -103,9 +105,9 @@ function poi_add_saf_variables_and_parameters_ctr_parameter_update(N::Int, M::In
                 ),
                 MOI.GreaterThan(1.0),
             )
-        MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
-        POI.update_parameters!(model)
     end
+    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    POI.update_parameters!(model)
     return nothing
 end
 
@@ -177,9 +179,9 @@ function poi_add_sqf_variables_parameters_ctr_parameter_update(N::Int, M::Int)
                 ),
                 MOI.GreaterThan(1.0),
             )
-        MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
-        POI.update_parameters!(model)
     end
+    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    POI.update_parameters!(model)
     return nothing
 end
 
@@ -217,9 +219,9 @@ function poi_add_sqf_parameters_parameters_ctr_parameter_update(N::Int, M::Int)
                 ),
                 MOI.GreaterThan(1.0),
             )
-        MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
-        POI.update_parameters!(model)
     end
+    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    POI.update_parameters!(model)
     return nothing
 end
 
@@ -287,9 +289,9 @@ function poi_add_saf_variables_and_parameters_obj_parameter_update(N::Int, M::In
                     0.0,
                 )
             )
-        MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
-        POI.update_parameters!(model)
     end
+    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    POI.update_parameters!(model)
     return nothing
 end
 
@@ -361,9 +363,9 @@ function poi_add_sqf_variables_parameters_obj_parameter_update(N::Int, M::Int)
                     0.0,
                 )
             )
-        MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
-        POI.update_parameters!(model)
     end
+    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    POI.update_parameters!(model)
     return nothing
 end
 
@@ -401,9 +403,9 @@ function poi_add_sqf_parameters_parameters_obj_parameter_update(N::Int, M::Int)
                     0.0,
                 )
             )
-        MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
-        POI.update_parameters!(model)
     end
+    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    POI.update_parameters!(model)
     return nothing
 end
 
@@ -469,20 +471,20 @@ function run_benchmarks(N::Int, M::Int)
     println("SQF objective with product of parameters on a POI.Optimizer.")
     @btime poi_add_sqf_parameters_parameters_obj($N, $M)
     GC.gc()
-    println("Update parameters in SAF constraint with parameters on a POI.Optimizer.")
+    println("Update parameters in SAF constraint with variables and parameters on a POI.Optimizer.")
     @btime poi_add_saf_variables_and_parameters_ctr_parameter_update($N, $M)
     GC.gc()
-    println("Update parameters in SAF objective with parameters on a POI.Optimizer.")
+    println("Update parameters in SAF objective with variables and parameters on a POI.Optimizer.")
     @btime poi_add_saf_variables_and_parameters_obj_parameter_update($N, $M)
     GC.gc()
-    println("Update parameters in SQF constraint with product of variables and parameters on a POI.Optimizer. M = 10")
-    @btime poi_add_sqf_variables_parameters_ctr_parameter_update($N, 10)
+    println("Update parameters in SQF constraint with product of variables and parameters on a POI.Optimizer.")
+    @btime poi_add_sqf_variables_parameters_ctr_parameter_update($N, $M)
     GC.gc()
     println("Update parameters in SQF constraint with product of parameters on a POI.Optimizer.")
     @btime poi_add_sqf_parameters_parameters_ctr_parameter_update($N, $M)
     GC.gc()
-    println("Update parameters in SQF objective with product of variables and parameters on a POI.Optimizer. M = 10")
-    @btime poi_add_sqf_variables_parameters_obj_parameter_update($N, 10)
+    println("Update parameters in SQF objective with product of variables and parameters on a POI.Optimizer.")
+    @btime poi_add_sqf_variables_parameters_obj_parameter_update($N, $M)
     GC.gc()
     println("Update parameters in SQF objective with product of parameters on a POI.Optimizer.")
     @btime poi_add_sqf_parameters_parameters_obj_parameter_update($N, $M)

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -282,8 +282,10 @@ function poi_add_saf_variables_and_parameters_obj_parameter_update(N::Int, M::In
                 )
             )
     end
-    MOI.set.(model, POI.ParameterValue(), y, 0.5)
-    POI.update_parameters!(model)
+    for _ in 1:M
+        MOI.set.(model, POI.ParameterValue(), y, 0.5)
+        POI.update_parameters!(model)
+    end
     return nothing
 end
 
@@ -354,8 +356,10 @@ function poi_add_sqf_variables_parameters_obj_parameter_update(N::Int, M::Int)
                 )
             )
     end
-    MOI.set.(model, POI.ParameterValue(), y, 0.5)
-    POI.update_parameters!(model)
+    for _ in 1:M
+        MOI.set.(model, POI.ParameterValue(), y, 0.5)
+        POI.update_parameters!(model)
+    end
     return nothing
 end
 
@@ -392,8 +396,10 @@ function poi_add_sqf_parameters_parameters_obj_parameter_update(N::Int, M::Int)
                 )
             )
     end
-    MOI.set.(model, POI.ParameterValue(), y, 0.5)
-    POI.update_parameters!(model)
+    for _ in 1:M
+        MOI.set.(model, POI.ParameterValue(), y, 0.5)
+        POI.update_parameters!(model)
+    end
     return nothing
 end
 

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -93,9 +93,7 @@ end
 function poi_add_saf_variables_and_parameters_ctr_parameter_update(N::Int, M::Int)
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     x = MOI.add_variables(model, N/2)
-    ycy = MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2))))
-    y = first.(ycy)
-    cy = map(x -> x[2], ycy)
+    y = first.(MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2)))))
     for _ in 1:M
         MOI.add_constraint(
                 model,
@@ -106,7 +104,7 @@ function poi_add_saf_variables_and_parameters_ctr_parameter_update(N::Int, M::In
                 MOI.GreaterThan(1.0),
             )
     end
-    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    MOI.set.(model, POI.ParameterValue(), y, 0.5)
     POI.update_parameters!(model)
     return nothing
 end
@@ -166,9 +164,7 @@ end
 function poi_add_sqf_variables_parameters_ctr_parameter_update(N::Int, M::Int)
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     x = MOI.add_variables(model, N/2)
-    ycy = MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2))))
-    y = first.(ycy)
-    cy = map(x -> x[2], ycy)
+    y = first.(MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2)))))
     for _ in 1:M
         MOI.add_constraint(
                 model,
@@ -180,7 +176,7 @@ function poi_add_sqf_variables_parameters_ctr_parameter_update(N::Int, M::Int)
                 MOI.GreaterThan(1.0),
             )
     end
-    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    MOI.set.(model, POI.ParameterValue(), y, 0.5)
     POI.update_parameters!(model)
     return nothing
 end
@@ -206,9 +202,7 @@ end
 function poi_add_sqf_parameters_parameters_ctr_parameter_update(N::Int, M::Int)
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     x = MOI.add_variables(model, N/2)
-    ycy = MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2))))
-    y = first.(ycy)
-    cy = map(x -> x[2], ycy)
+    y = first.(MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2)))))
     for _ in 1:M
         MOI.add_constraint(
                 model,
@@ -220,7 +214,7 @@ function poi_add_sqf_parameters_parameters_ctr_parameter_update(N::Int, M::Int)
                 MOI.GreaterThan(1.0),
             )
     end
-    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    MOI.set.(model, POI.ParameterValue(), y, 0.5)
     POI.update_parameters!(model)
     return nothing
 end
@@ -277,9 +271,7 @@ end
 function poi_add_saf_variables_and_parameters_obj_parameter_update(N::Int, M::Int)
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     x = MOI.add_variables(model, N/2)
-    ycy = MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2))))
-    y = first.(ycy)
-    cy = map(x -> x[2], ycy)
+    y = first.(MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2)))))
     for _ in 1:M
         MOI.set(
                 model,
@@ -290,7 +282,7 @@ function poi_add_saf_variables_and_parameters_obj_parameter_update(N::Int, M::In
                 )
             )
     end
-    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    MOI.set.(model, POI.ParameterValue(), y, 0.5)
     POI.update_parameters!(model)
     return nothing
 end
@@ -350,9 +342,7 @@ end
 function poi_add_sqf_variables_parameters_obj_parameter_update(N::Int, M::Int)
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     x = MOI.add_variables(model, N/2)
-    ycy = MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2))))
-    y = first.(ycy)
-    cy = map(x -> x[2], ycy)
+    y = first.(MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2)))))
     for _ in 1:M
         MOI.set(
                 model,
@@ -364,7 +354,7 @@ function poi_add_sqf_variables_parameters_obj_parameter_update(N::Int, M::Int)
                 )
             )
     end
-    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    MOI.set.(model, POI.ParameterValue(), y, 0.5)
     POI.update_parameters!(model)
     return nothing
 end
@@ -390,9 +380,7 @@ end
 function poi_add_sqf_parameters_parameters_obj_parameter_update(N::Int, M::Int)
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     x = MOI.add_variables(model, N/2)
-    ycy = MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2))))
-    y = first.(ycy)
-    cy = map(x -> x[2], ycy)
+    y = first.(MOI.add_constrained_variable.(model, POI.Parameter.(ones(Int(N/2)))))
     for _ in 1:M
         MOI.set(
                 model,
@@ -404,7 +392,7 @@ function poi_add_sqf_parameters_parameters_obj_parameter_update(N::Int, M::Int)
                 )
             )
     end
-    MOI.set.(model, MOI.ConstraintSet(), cy, POI.Parameter.(0.5))
+    MOI.set.(model, POI.ParameterValue(), y, 0.5)
     POI.update_parameters!(model)
     return nothing
 end


### PR DESCRIPTION
The updates benchmarks were a bit misleading, now we can understand better the price of updating the objective 100 times and updating 100 constraints once. These benchmarks are more helpful to understand POI overhead than the previous ones.