### PR TITLE
[WIP] POI + DiffOpt = S2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.7.0"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+DiffOpt = "930fe3bc-9c6b-11ea-2d94-6184641e85e7"
 
 [compat]
 GLPK = "1"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -99,7 +99,9 @@ function MOI.is_empty(model::Optimizer)
            #
            isempty(model.multiplicative_parameters) &&
            isempty(model.dual_value_of_parameters) &&
-           model.number_of_parameters_in_model == 0
+           model.number_of_parameters_in_model == 0 &&
+           isempty(model.parameter_input_forward) &&
+           isempty(model.parameter_output_backward)
 end
 
 function MOI.empty!(model::Optimizer{T}) where {T}
@@ -133,6 +135,8 @@ function MOI.empty!(model::Optimizer{T}) where {T}
     empty!(model.dual_value_of_parameters)
     #
     model.number_of_parameters_in_model = 0
+    empty!(model.parameter_input_forward)
+    empty!(model.parameter_output_backward)
     return
 end
 

--- a/src/ParametricOptInterface.jl
+++ b/src/ParametricOptInterface.jl
@@ -162,6 +162,10 @@ mutable struct Optimizer{T,OT<:MOI.ModelLike} <: MOI.AbstractOptimizer
     number_of_parameters_in_model::Int64
     constraints_interpretation::ConstraintsInterpretationCode
     save_original_objective_and_constraints::Bool
+
+    # sensitivity data
+    parameter_input_forward::Dict{ParameterIndex,T}
+    parameter_output_backward::Dict{ParameterIndex,T}
     function Optimizer(
         optimizer::OT;
         evaluate_duals::Bool = true,
@@ -219,6 +223,8 @@ mutable struct Optimizer{T,OT<:MOI.ModelLike} <: MOI.AbstractOptimizer
             0,
             ONLY_CONSTRAINTS,
             save_original_objective_and_constraints,
+            Dict{ParameterIndex,T}(),
+            Dict{ParameterIndex,T}(),
         )
     end
 end
@@ -248,5 +254,6 @@ end
 include("duals.jl")
 include("update_parameters.jl")
 include("MOI_wrapper.jl")
+include("diff.jl")
 
 end # module

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -1,0 +1,228 @@
+using DiffOpt
+
+# forward mode
+
+function DiffOpt.forward_differentiate!(model::Optimizer{T}) where {T}
+    # TODO: add a reset option
+    for (F, S) in keys(model.affine_constraint_cache.dict)
+        affine_constraint_cache_inner = model.affine_constraint_cache[F, S]
+        if !isempty(affine_constraint_cache_inner)
+            # TODO add: barrier to avoid type instability of inner dicts
+            for (inner_ci, pf) in affine_constraint_cache_inner
+                cte = zero(T)
+                terms = MOI.ScalarAffineTerm{T}[]
+                sizehint!(terms, 0)
+                if length(pf.p) != 0
+                    for term in pf.p
+                        p = p_idx(term.variable)
+                        sensitivity = get(model.parameter_input_forward, p, 0.0)
+                        # TODO: check sign
+                        cte += sensitivity * term.coefficient
+                    end
+                    # TODO: if cte != 0
+                    MOI.set(
+                        model.optimizer,
+                        DiffOpt.ForwardConstraintFunction(),
+                        inner_ci,
+                        MOI.ScalarAffineFunction{T}(terms, cte),
+                    )
+                end
+            end
+        end
+    end
+    for (F, S) in keys(model.vector_affine_constraint_cache.dict)
+        vector_affine_constraint_cache_inner =
+            model.vector_affine_constraint_cache[F, S]
+        if !isempty(vector_affine_constraint_cache_inner)
+            # barrier to avoid type instability of inner dicts
+            for (inner_ci, pf) in vector_affine_constraint_cache_inner
+                cte = zeros(T, length(pf.c))
+                terms = MOI.VectorAffineTerm{T}[]
+                sizehint!(terms, 0)
+                if length(pf.p) != 0
+                    for term in pf.p
+                        p = p_idx(term.scalar_term.variable)
+                        sensitivity = get(model.parameter_input_forward, p, 0.0)
+                        # TODO: check sign
+                        cte[term.output_index] += sensitivity * term.scalar_term.coefficient
+                    end
+                    # TODO: if cte != 0
+                    MOI.set(
+                        model.optimizer,
+                        DiffOpt.ForwardConstraintFunction(),
+                        inner_ci,
+                        MOI.ScalarAffineFunction{T}(terms, cte),
+                    )
+                end
+            end
+        end
+    end
+    for (F, S) in keys(model.quadratic_constraint_cache.dict)
+        quadratic_constraint_cache_inner =
+            model.quadratic_constraint_cache[F, S]
+        if !isempty(quadratic_constraint_cache_inner)
+            # TODO add: barrier to avoid type instability of inner dicts
+            for (inner_ci, pf) in quadratic_constraint_cache_inner
+                cte = zero(T)
+                terms = MOI.ScalarAffineTerm{T}[]
+                # terms_dict = Dict{MOI.VariableIndex,T}() # canonicalize?
+                sizehint!(terms, length(pf.pv))
+                if length(pf.p) != 0 || length(pf.pv) != 0 || length(pf.pp) != 0
+                    for term in pf.p
+                        p = p_idx(term.variable)
+                        sensitivity = get(model.parameter_input_forward, p, 0.0)
+                        # TODO: check sign
+                        cte += sensitivity * term.coefficient
+                    end
+                    for term in pf.pp
+                        p_1 = p_idx(term.variable_1)
+                        p_2 = p_idx(term.variable_2)
+                        sensitivity_1 = get(model.parameter_input_forward, p_1, 0.0)
+                        sensitivity_2 = get(model.parameter_input_forward, p_2, 0.0)
+                        cte += sensitivity_1 * sensitivity_2 * term.coefficient
+                    end
+                    # canonicalize?
+                    for term in pf.pv
+                        p = p_idx(term.variable_1)
+                        sensitivity = get(model.parameter_input_forward, p, NaN)
+                        if !isnan(sensitivity)
+                            push!(
+                                terms,
+                                MOI.ScalarAffineTerm{T}(
+                                    sensitivity * term.coefficient,
+                                    term.variable_2,
+                                ),
+                            )
+                        end
+                    end
+                    MOI.set(
+                        model.optimizer,
+                        DiffOpt.ForwardConstraintFunction(),
+                        inner_ci,
+                        MOI.ScalarAffineFunction{T}(terms, cte),
+                    )
+                end
+            end
+        end
+    end
+    if model.affine_objective_cache !== nothing
+        cte = zero(T)
+        terms = MOI.ScalarAffineTerm{T}[]
+        pf = model.affine_objective_cache
+        sizehint!(terms, 0)
+        if length(pf.p) != 0
+            for term in pf.p
+                p = p_idx(term.variable)
+                sensitivity = get(model.parameter_input_forward, p, 0.0)
+                # TODO: check sign
+                cte += sensitivity * term.coefficient
+            end
+            # TODO: if cte != 0
+            MOI.set(
+                model.optimizer,
+                DiffOpt.ForwardObjectiveFunction(),
+                inner_ci,
+                MOI.ScalarAffineFunction{T}(terms, cte),
+            )
+        end
+    elseif model.quadratic_objective_cache !== nothing
+        cte = zero(T)
+        terms = MOI.ScalarAffineTerm{T}[]
+        pf = model.quadratic_objective_cache
+        sizehint!(terms, length(pf.pv))
+        if length(pf.p) != 0
+            for term in pf.p
+                p = p_idx(term.variable)
+                sensitivity = get(model.parameter_input_forward, p, 0.0)
+                # TODO: check sign
+                cte += sensitivity * term.coefficient
+            end
+            for term in pf.pp
+                p_1 = p_idx(term.variable_1)
+                p_2 = p_idx(term.variable_2)
+                sensitivity_1 = get(model.parameter_input_forward, p_1, 0.0)
+                sensitivity_2 = get(model.parameter_input_forward, p_2, 0.0)
+                cte += sensitivity_1 * sensitivity_2 * term.coefficient
+            end
+            # canonicalize?
+            for term in pf.pv
+                p = p_idx(term.variable_1)
+                sensitivity = get(model.parameter_input_forward, p, NaN)
+                if !isnan(sensitivity)
+                    push!(
+                        terms,
+                        MOI.ScalarAffineTerm{T}(
+                            sensitivity * term.coefficient,
+                            term.variable_2,
+                        ),
+                    )
+                end
+            end
+            # TODO: if cte != 0
+            MOI.set(
+                model.optimizer,
+                DiffOpt.ForwardObjectiveFunction(),
+                inner_ci,
+                MOI.ScalarAffineFunction{T}(terms, cte),
+            )
+        end
+    end
+    DiffOpt.forward_differentiate!(model.optimizer)
+    return
+end
+
+struct ForwardParameter <: MOI.AbstractVariableAttribute end
+
+function MOI.set(
+    model::Optimizer,
+    ::ForwardParameter,
+    variable::MOI.VariableIndex,
+    value::Number,
+)
+    if _is_variable(variable)
+        error("Trying to set a parameter sensitivity for a variable")
+    end
+    parameter = p_idx(variable)
+    model.parameter_input_forward[parameter] = value
+    return
+end
+
+function MOI.get(
+    model::Optimizer,
+    attr::DiffOpt.ForwardVariablePrimal,
+    variable::MOI.VariableIndex,
+)
+    if _is_parameter(variable)
+        error("Trying to get a variable sensitivity for a parameter")
+    end
+    return MOI.get(model.optimizer, attr, model.variables[variable])
+end
+
+# reverse mode
+
+function DiffOpt.reverse_differentiate!(model::Optimizer)
+    error("Not implemented")
+    DiffOpt.reverse_differentiate!(model.optimizer)
+    return
+end
+
+function MOI.set(
+    model::Optimizer,
+    attr::DiffOpt.ReverseVariablePrimal,
+    variable::MOI.VariableIndex,
+    value::Number,
+)
+    MOI.set(model.optimizer, attr, variable, value)
+    return
+end
+
+struct ReverseParameter <: MOI.AbstractVariableAttribute end
+
+function MOI.get(
+    model::Optimizer,
+    attr::ReverseParameter,
+    variable::MOI.VariableIndex,
+)
+    error("Not implemented")
+    return
+end

--- a/test/jump_diff_param.jl
+++ b/test/jump_diff_param.jl
@@ -1,0 +1,144 @@
+# using Revise
+
+using JuMP
+using DiffOpt
+using Test
+import ParametricOptInterface as POI
+
+function test_diff_rhs()
+    model = Model(() ->
+        POI.Optimizer(
+            DiffOpt.Optimizer(
+                GLPK.Optimizer()
+            )
+        )
+    )
+    @variable(model, x)
+    @variable(model, p in MOI.Parameter(3.0))
+    @constraint(model, cons, x >= 3 * p)
+    @objective(model, Min, 2x)
+    optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 9
+    # the function is
+    # x(p) = 3p, hence x'(p) = 3
+    # differentiate w.r.t. p
+    MOI.set(model, POI.ForwardParameter(), p, 1)
+    DiffOpt.forward_differentiate!(model)
+    @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ 3
+    # again with different "direction"
+    MOI.set(model, POI.ForwardParameter(), p, 2)
+    DiffOpt.forward_differentiate!(model)
+    @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ 6
+    #
+    MOI.set(model, POI.ParameterValue(), p, 2.0)
+    optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 6
+    # differentiate w.r.t. p
+    MOI.set(model, POI.ForwardParameter(), p, 1)
+    DiffOpt.forward_differentiate!(model)
+    @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ 3
+    # again with different "direction"
+    MOI.set(model, POI.ForwardParameter(), p, 2)
+    DiffOpt.forward_differentiate!(model)
+    @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ 6
+    return
+end
+
+function test_affine_changes()
+    model = Model(() ->
+        POI.Optimizer(
+            DiffOpt.Optimizer(
+                GLPK.Optimizer()
+            )
+        )
+    )
+    p_val = 3.0
+    pc_val = 1.0
+    @variable(model, x)
+    @variable(model, p in MOI.Parameter(p_val))
+    @variable(model, pc in MOI.Parameter(pc_val))
+    @constraint(model, cons, pc * x >= 3 * p)
+    @objective(model, Min, 2x)
+    optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 3 * p_val / pc_val
+    # the function is
+    # x(p, pc) = 3p / pc, hence dx/dp = 3 / pc, dx/dpc = -3p / pc^2
+    # differentiate w.r.t. p
+    for direction_p = 1:2
+        MOI.set(model, POI.ForwardParameter(), p, direction_p)
+        DiffOpt.forward_differentiate!(model)
+        @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ direction_p * 3 / pc_val
+    end
+    # update p
+    p_val = 2.0
+    MOI.set(model, POI.ParameterValue(), p, p_val)
+    optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 3 * p_val / pc_val
+    # differentiate w.r.t. p
+    for direction_p = 1:2
+        MOI.set(model, POI.ForwardParameter(), p, direction_p)
+        DiffOpt.forward_differentiate!(model)
+        @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ direction_p * 3 / pc_val
+    end
+    # differentiate w.r.t. pc
+    # stop differentiating with respect to p
+    direction_p = 0.0
+    MOI.set(model, POI.ForwardParameter(), p, direction_p)
+    for direction_pc = 1:2
+        MOI.set(model, POI.ForwardParameter(), pc, direction_pc)
+        DiffOpt.forward_differentiate!(model)
+        @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ - direction_pc * 3 * p_val / pc_val^2
+    end
+    # update pc
+    pc_val = 2.0
+    MOI.set(model, POI.ParameterValue(), pc, pc_val)
+    optimize!(model)
+    @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 3 * p_val / pc_val
+    for direction_pc = 1:2
+        MOI.set(model, POI.ForwardParameter(), pc, direction_pc)
+        DiffOpt.forward_differentiate!(model)
+        @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈ - direction_pc * 3 * p_val / pc_val^2
+    end
+    # test combines directions
+    for direction_pc = 1:2, direction_p = 1:2
+        MOI.set(model, POI.ForwardParameter(), p, direction_p)
+        MOI.set(model, POI.ForwardParameter(), pc, direction_pc)
+        DiffOpt.forward_differentiate!(model)
+        @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈
+            - direction_pc * 3 * p_val / pc_val^2 + direction_p * 3 / pc_val
+    end
+    return
+end
+
+function test_affine_changes_compact()
+    model = Model(() ->
+        POI.Optimizer(
+            DiffOpt.Optimizer(
+                GLPK.Optimizer()
+            )
+        )
+    )
+    p_val = 3.0
+    pc_val = 1.0
+    @variable(model, x)
+    @variable(model, p in MOI.Parameter(p_val))
+    @variable(model, pc in MOI.Parameter(pc_val))
+    @constraint(model, cons, pc * x >= 3 * p)
+    @objective(model, Min, 2x)
+    # the function is
+    # x(p, pc) = 3p / pc, hence dx/dp = 3 / pc, dx/dpc = -3p / pc^2
+    for p_val = 1:3, pc_val = 1:3
+        MOI.set(model, POI.ParameterValue(), p, p_val)
+        MOI.set(model, POI.ParameterValue(), pc, pc_val)
+        optimize!(model)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 3 * p_val / pc_val
+        for direction_pc = 0:2, direction_p = 0:2
+            MOI.set(model, POI.ForwardParameter(), p, direction_p)
+            MOI.set(model, POI.ForwardParameter(), pc, direction_pc)
+            DiffOpt.forward_differentiate!(model)
+            @test MOI.get(model, DiffOpt.ForwardVariablePrimal(), x) ≈
+                - direction_pc * 3 * p_val / pc_val^2 + direction_p * 3 / pc_val
+        end
+    end
+    return
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
 
 include("moi_tests.jl")
 include("jump_tests.jl")
+include("jump_diff_param.jl")
 
 for name in names(@__MODULE__; all = true)
     if startswith("$name", "test_")


### PR DESCRIPTION
@andrewrosemberg motivated me.

I love how well layers can play with each other.

This will not be merged (as part of POI src) as it does not make sense to add DiffOpt as a dep for POI.

This should be either:
1 - An extension here (POI)
2 - A separate package
3 - An extension at DiffOpt

Semantically, option 3 makes lots of sense. But this uses too much of POI internals. Option 2 has a similar issue, we will have to pin a POI version.
Currently, I like 1.

Still requires:

- [ ] Reverse mode
- [ ] More tests (objectives, vector affine, more constraints...)
- [ ] Deal with cached data (a reset_input_sensitivities in DiffOpt would be handy)
- [ ] Move it to the right place

cc @matbesancon, @blegat