### PR TITLE
Remove dual solution warning from optimize!

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1367,7 +1367,8 @@ function MOI.optimize!(model::Optimizer)
         _set_quadratic_product_in_obj!(model)
     end
     MOI.optimize!(model.optimizer)
-    if MOI.get(model, MOI.DualStatus()) != MOI.NO_SOLUTION && model.evaluate_duals
+    if MOI.get(model, MOI.DualStatus()) != MOI.NO_SOLUTION &&
+        model.evaluate_duals
         _compute_dual_of_parameters!(model)
     end
     return

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1091,18 +1091,6 @@ function MOI.get(
     return MOI.get(model.optimizer, attr, optimizer_ci)
 end
 
-function MOI.get(
-    model::Optimizer,
-    attr::MOI.ConstraintDual,
-    c::MOI.ConstraintIndex{MOI.VariableIndex,MOI.Parameter{T}},
-) where {T}
-    if !model.evaluate_duals
-        error()
-    end
-    optimizer_ci = get(model.constraint_outer_to_inner, c, c)
-    return MOI.get(model.optimizer, attr, optimizer_ci)
-end
-
 #
 # Special Attributes
 #

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1368,7 +1368,7 @@ function MOI.optimize!(model::Optimizer)
     end
     MOI.optimize!(model.optimizer)
     if MOI.get(model, MOI.DualStatus()) != MOI.NO_SOLUTION &&
-        model.evaluate_duals
+       model.evaluate_duals
         _compute_dual_of_parameters!(model)
     end
     return

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1367,7 +1367,7 @@ function MOI.optimize!(model::Optimizer)
         _set_quadratic_product_in_obj!(model)
     end
     MOI.optimize!(model.optimizer)
-    if model.evaluate_duals
+    if MOI.get(model, MOI.DualStatus()) != MOI.NO_SOLUTION && model.evaluate_duals
         _compute_dual_of_parameters!(model)
     end
     return

--- a/src/duals.jl
+++ b/src/duals.jl
@@ -126,6 +126,16 @@ function MOI.get(
     ::MOI.ConstraintDual,
     cp::MOI.ConstraintIndex{MOI.VariableIndex,MOI.Parameter{T}},
 ) where {T}
+    if !model.evaluate_duals
+        throw(
+            MOI.GetAttributeNotAllowed(
+                MOI.ConstraintDual(),
+                "$(MOI.ConstraintDual()) not available when " *
+                "evaluate_duals is set to false. " *
+                "Create an optimizer such as POI.Optimizer(HiGHS.Optimizer(); evaluate_duals = true) to enable this feature.",
+            ),
+        )
+    end
     if !_is_additive(model, cp)
         error("Cannot compute the dual of a multiplicative parameter")
     end

--- a/test/moi_tests.jl
+++ b/test/moi_tests.jl
@@ -1613,3 +1613,37 @@ function test_compute_conflict!()
     @test MOI.get(model, MOI.ConstraintConflictStatus(), ci) == MOI.IN_CONFLICT
     return
 end
+
+function test_duals_not_available()
+    optimizer = POI.Optimizer(GLPK.Optimizer(); evaluate_duals = false)
+    MOI.set(optimizer, MOI.Silent(), true)
+    x = MOI.add_variables(optimizer, 2)
+    y, cy = MOI.add_constrained_variable(optimizer, MOI.Parameter(0.0))
+    z = MOI.VariableIndex(4)
+    cz = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Parameter{Float64}}(4)
+    for x_i in x
+        MOI.add_constraint(optimizer, x_i, MOI.GreaterThan(0.0))
+    end
+    cons1 = MOI.ScalarAffineFunction(
+        MOI.ScalarAffineTerm.([1.0, 1.0], [x[1], y]),
+        0.0,
+    )
+    c1 = MOI.add_constraint(optimizer, cons1, MOI.EqualTo(2.0))
+    obj_func = MOI.ScalarAffineFunction(
+        MOI.ScalarAffineTerm.([1.0, 1.0], [x[1], y]),
+        0.0,
+    )
+    MOI.set(
+        optimizer,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        obj_func,
+    )
+    MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.optimize!(optimizer)
+    @test_throws MOI.GetAttributeNotAllowed MOI.get(
+        optimizer,
+        MOI.ConstraintDual(),
+        cy,
+    )
+    return
+end


### PR DESCRIPTION
Replace "Dual solution not available" warning in `MOI.optimize!` with an error in `MOI.get`. Otherwise, a warning is shown even when duals are not requested.