### PR TITLE
Update constraint indexes when adding constraints without parameters

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -222,6 +222,18 @@ function _add_to_constraint_map!(model::Optimizer, ci)
     return
 end
 
+function _add_to_constraint_map!(model::Optimizer, ci::MOI.ConstraintIndex{F,S}) where {F<:MOI.ScalarAffineFunction, S}
+    model.last_affine_added += 1
+    model.constraint_outer_to_inner[ci] = ci
+    return
+end
+
+function _add_to_constraint_map!(model::Optimizer, ci::MOI.ConstraintIndex{F,S}) where {F<:MOI.ScalarQuadraticFunction, S}
+    model.last_quad_add_added += 1
+    model.constraint_outer_to_inner[ci] = ci
+    return
+end
+
 function MOI.supports(
     model::Optimizer,
     attr::MOI.AbstractVariableAttribute,

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -222,13 +222,19 @@ function _add_to_constraint_map!(model::Optimizer, ci)
     return
 end
 
-function _add_to_constraint_map!(model::Optimizer, ci::MOI.ConstraintIndex{F,S}) where {F<:MOI.ScalarAffineFunction, S}
+function _add_to_constraint_map!(
+    model::Optimizer,
+    ci::MOI.ConstraintIndex{F,S},
+) where {F<:MOI.ScalarAffineFunction,S}
     model.last_affine_added += 1
     model.constraint_outer_to_inner[ci] = ci
     return
 end
 
-function _add_to_constraint_map!(model::Optimizer, ci::MOI.ConstraintIndex{F,S}) where {F<:MOI.ScalarQuadraticFunction, S}
+function _add_to_constraint_map!(
+    model::Optimizer,
+    ci::MOI.ConstraintIndex{F,S},
+) where {F<:MOI.ScalarQuadraticFunction,S}
     model.last_quad_add_added += 1
     model.constraint_outer_to_inner[ci] = ci
     return

--- a/test/moi_tests.jl
+++ b/test/moi_tests.jl
@@ -1659,10 +1659,7 @@ function test_duals_without_parameters()
         0.0,
     )
     c1 = MOI.add_constraint(optimizer, cons1, MOI.LessThan(0.0))
-    cons2 = MOI.ScalarAffineFunction(
-        MOI.ScalarAffineTerm.([1.0], [x[2]]),
-        0.0,
-    )
+    cons2 = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[2])], 0.0)
     c2 = MOI.add_constraint(optimizer, cons2, MOI.LessThan(1.0))
     cons3 = MOI.ScalarAffineFunction(
         MOI.ScalarAffineTerm.([1.0, -1.0], [x[3], z]),


### PR DESCRIPTION
When alternating between constraints with and without parameters, the `model.constraint_outer_to_inner` Dict would lose track of the constraint indexes. 
In the new test, without the changes, the dual for c2 returns -3.0.