### PR TITLE
Convert quadratic to affine even when there is no parameters

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -789,12 +789,16 @@ function MOI.add_constraint(
         # function like the other entries.
         if _is_affine(f)
             fa = MOI.ScalarAffineFunction(f.affine_terms, f.constant)
-            inner_ci =
-                MOI.Utilities.normalize_and_add_constraint(model.optimizer, fa, set)
-            model.last_quad_add_added += 1
-            outer_ci = MOI.ConstraintIndex{MOI.ScalarQuadraticFunction{T},typeof(set)}(
-                model.last_quad_add_added,
+            inner_ci = MOI.Utilities.normalize_and_add_constraint(
+                model.optimizer,
+                fa,
+                set,
             )
+            model.last_quad_add_added += 1
+            outer_ci =
+                MOI.ConstraintIndex{MOI.ScalarQuadraticFunction{T},typeof(set)}(
+                    model.last_quad_add_added,
+                )
             model.quadratic_outer_to_inner[outer_ci] = inner_ci
             model.constraint_outer_to_inner[outer_ci] = inner_ci
             return outer_ci

--- a/test/moi_tests.jl
+++ b/test/moi_tests.jl
@@ -1899,3 +1899,23 @@ function test_getters()
     ) isa POI.ParametricQuadraticFunction{Float64}
     return
 end
+
+function test_no_quadratic_terms()
+    optimizer = POI.Optimizer(GLPK.Optimizer())
+    MOI.set(optimizer, MOI.Silent(), true)
+    x = MOI.add_variable(optimizer)
+    y, cy = MOI.add_constrained_variable(optimizer, MOI.Parameter(1.0))
+    MOI.add_constraint(optimizer, 1.0 * x * y + 1.0 * x + 1.0 * y  - 1.0 * x * y, MOI.LessThan(0.0))
+    MOI.set(
+        optimizer,
+        MOI.ObjectiveSense(),
+        MOI.MAX_SENSE,
+    )
+    obj_func = 1.0 * x + 2.0 * y
+    MOI.set(
+        optimizer,
+        MOI.ObjectiveFunction{typeof(obj_func)}(),
+        obj_func,
+    )
+    return
+end


### PR DESCRIPTION
I am playing around using POI with SumOfSquares and was hitting an error for `f - g * p` if `p` is a parameter and `g` has less monomials than `f`. Indeed, this will create scalar quadratic constraint with no quadratic term and with no parameter which currently fails.
This PR should fix it