### PR TITLE
Fix bridging cost

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -601,6 +601,16 @@ function MOI.supports_constraint(
     )
 end
 
+function MOI.get(
+    model::Optimizer{T},
+    ::MOI.ConstraintBridgingCost{MOI.ScalarQuadraticFunction{T},S},
+) where {T,S<:MOI.AbstractSet}
+    return MOI.get(
+        model.optimizer,
+        MOI.ConstraintBridgingCost{MOI.ScalarAffineFunction{T},S}(),
+    )
+end
+
 function MOI.supports_constraint(
     model::Optimizer,
     ::Type{MOI.VectorQuadraticFunction{T}},
@@ -610,6 +620,16 @@ function MOI.supports_constraint(
         model.optimizer,
         MOI.VectorAffineFunction{T},
         S,
+    )
+end
+
+function MOI.get(
+    model::Optimizer{T},
+    ::MOI.ConstraintBridgingCost{MOI.VectorQuadraticFunction{T},S},
+) where {T,S<:MOI.AbstractSet}
+    return MOI.get(
+        model.optimizer,
+        MOI.ConstraintBridgingCost{MOI.VectorAffineFunction{T},S}(),
     )
 end
 

--- a/test/test_MathOptInterface.jl
+++ b/test/test_MathOptInterface.jl
@@ -2111,6 +2111,46 @@ function test_constrained_variables()
     return
 end
 
+function test_constraint_bridging_cost_quadratic()
+    # POI rewrites `Vector/ScalarQuadraticFunction` constraints into their
+    # affine counterparts at solve time, so `supports_constraint` for the
+    # quadratic variant delegates to the affine one. `ConstraintBridgingCost`
+    # must do the same: otherwise `LazyBridgeOptimizer` sees
+    # `supports = true, cost = Inf` and treats the node as unreachable when
+    # building the bridge graph.
+    optimizer = POI.Optimizer(SCS.Optimizer)
+    for S in (MOI.Zeros, MOI.Nonnegatives, MOI.SecondOrderCone)
+        @test MOI.supports_constraint(
+            optimizer,
+            MOI.VectorQuadraticFunction{Float64},
+            S,
+        )
+        @test MOI.get(
+            optimizer,
+            MOI.ConstraintBridgingCost{MOI.VectorQuadraticFunction{Float64},S}(),
+        ) == MOI.get(
+            optimizer,
+            MOI.ConstraintBridgingCost{MOI.VectorAffineFunction{Float64},S}(),
+        )
+    end
+    optimizer = POI.Optimizer(HiGHS.Optimizer)
+    for S in (MOI.LessThan{Float64}, MOI.GreaterThan{Float64}, MOI.EqualTo{Float64})
+        @test MOI.supports_constraint(
+            optimizer,
+            MOI.ScalarQuadraticFunction{Float64},
+            S,
+        )
+        @test MOI.get(
+            optimizer,
+            MOI.ConstraintBridgingCost{MOI.ScalarQuadraticFunction{Float64},S}(),
+        ) == MOI.get(
+            optimizer,
+            MOI.ConstraintBridgingCost{MOI.ScalarAffineFunction{Float64},S}(),
+        )
+    end
+    return
+end
+
 function test_parameter_index_error()
     model = POI.Optimizer(MOI.Utilities.Model{Float64}())
     POI._add_variable(model, MOI.VariableIndex(1))

--- a/test/test_MathOptInterface.jl
+++ b/test/test_MathOptInterface.jl
@@ -2134,7 +2134,8 @@ function test_constraint_bridging_cost_quadratic()
         )
     end
     optimizer = POI.Optimizer(HiGHS.Optimizer)
-    for S in (MOI.LessThan{Float64}, MOI.GreaterThan{Float64}, MOI.EqualTo{Float64})
+    for S in
+        (MOI.LessThan{Float64}, MOI.GreaterThan{Float64}, MOI.EqualTo{Float64})
         @test MOI.supports_constraint(
             optimizer,
             MOI.ScalarQuadraticFunction{Float64},


### PR DESCRIPTION
As quadratic constraints are converted to affine, we should transform the bridging cost attribute as well. Detected by the solver-tests in https://github.com/jump-dev/MathOptInterface.jl/pull/3001